### PR TITLE
シナリオ作成画面の保守性向上のためのリファクタリング

### DIFF
--- a/frontend/src/pages/CreateScenario/CharacterSheet/index.tsx
+++ b/frontend/src/pages/CreateScenario/CharacterSheet/index.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import CharacterSheetPresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 
 const CharacterSheet = () => {
-  const {setIsCreatingCharacter, setIsOther, setPhase, setIsWorld} =
-    useCreateScenario();
+  const {setPhase, transitNextState} = useCreateScenario();
   const onPress = (type: string) => {
     if (type === 'ai') {
-      setIsCreatingCharacter(false);
-      setIsOther(false);
-      setIsWorld(true);
+      transitNextState(CreateState.World);
       setPhase(prev => prev + 1);
     }
   };

--- a/frontend/src/pages/CreateScenario/Header/index.tsx
+++ b/frontend/src/pages/CreateScenario/Header/index.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import HeaderPresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootRoutesParamList} from '../../../routes/Root';
 
@@ -13,22 +13,49 @@ type Props = {
 };
 
 const Header = ({navigation}: Props) => {
-  const {tabId, setTabId, phase, setPhase, setIsCreatingCharacter} =
-    useCreateScenario();
+  const {
+    phase,
+    setPhase,
+    setIsCreatingCharacter,
+    createState,
+    pageStack,
+    transitPrevState,
+  } = useCreateScenario();
   const [headerText, setHeaderText] = useState<string>('シナリオ作成');
   useEffect(() => {
-    if (tabId === 1 && phase === 1) setHeaderText('シナリオ作成');
-    else if (tabId === 1 && phase === 2) setHeaderText('キャラクターシート');
-    else if (tabId === 1 && phase === 3) setHeaderText('世界観を決める');
-    else if (tabId === 1 && phase === 4) setHeaderText('ヒントを選ぶ');
-    else if (tabId === 1 && phase === 5)
-      setHeaderText('使用するトリックを選ぶ');
-    else if (tabId === 2 && phase === 1) setHeaderText('シナリオを作成');
-    else if (tabId === 2 && phase === 2) setHeaderText('証拠品/情報');
-    else if (tabId === 2 && phase === 3) setHeaderText('画像作成');
-  }, [tabId, phase]);
+    switch (createState) {
+      case CreateState.CliminalCharacter:
+      case CreateState.OtherCharacter:
+        setHeaderText('キャラクターシート');
+        break;
+      case CreateState.World:
+        setHeaderText('世界観を決める');
+        break;
+      case CreateState.Hint:
+        setHeaderText('ヒントを選ぶ');
+        break;
+      case CreateState.Trick:
+        setHeaderText('使用するトリックを選ぶ');
+        break;
+      case CreateState.ItemInfo:
+        setHeaderText('証拠品/情報');
+        break;
+      case CreateState.Image:
+        setHeaderText('画像作成');
+        break;
+      default:
+        setHeaderText('シナリオ作成');
+        break;
+    }
+  }, [createState]);
 
   const back = () => {
+    transitPrevState();
+
+    if (pageStack.length === 0) {
+      navigation.navigate('ServerSelect');
+    }
+
     if (phase === 2) {
       setIsCreatingCharacter(false);
     }

--- a/frontend/src/pages/CreateScenario/Hint/index.tsx
+++ b/frontend/src/pages/CreateScenario/Hint/index.tsx
@@ -1,11 +1,12 @@
 import React, {useState} from 'react';
 import HintPresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
+import Create from 'agora-rn-uikit/src/Rtc/Create';
 
 const Hint = () => {
   const [sendItems, setSendItems] = useState<string[]>([]);
   const [sendPhenomena, setSendPhenomena] = useState<string[]>([]);
-  const {setIsHint, setPhase, setIsTrick, setTricks, shareJson} =
+  const {setPhase, setTricks, shareJson, transitNextState} =
     useCreateScenario();
 
   const addItem = (item: string) => {
@@ -44,8 +45,7 @@ const Hint = () => {
     console.log(res.trivia);
     setTricks([...res.item, ...res.trivia]);
 
-    setIsHint(false);
-    setIsTrick(true);
+    transitNextState(CreateState.Trick);
     setPhase(prev => prev + 1);
   };
   return <HintPresenter funcs={{addItem, addPhenomena}} next={next} />;

--- a/frontend/src/pages/CreateScenario/ItemInfo/index.tsx
+++ b/frontend/src/pages/CreateScenario/ItemInfo/index.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
 import ItemInfoPresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 
 const ItemInfo = () => {
   const [showModal, setShowModal] = useState(false);
-  const {setIsImageCreate, setIsItemInfo, setPhase} = useCreateScenario();
+  const {setPhase, setCreateState} = useCreateScenario();
   const openModal = () => {
     setShowModal(true);
   };
@@ -14,9 +14,9 @@ const ItemInfo = () => {
 
   const next = () => {
     setPhase(prev => prev + 1);
-    setIsItemInfo(false);
-    setIsImageCreate(true);
+    setCreateState(CreateState.Image);
   };
+
   return (
     <ItemInfoPresenter
       showModal={showModal}

--- a/frontend/src/pages/CreateScenario/SelectCharacterType/index.tsx
+++ b/frontend/src/pages/CreateScenario/SelectCharacterType/index.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import SelectCharacterTypePresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 
 const SelectCharacterType = () => {
-  const {setIsCreatingCharacter, setIsOther, setPhase, phase} =
-    useCreateScenario();
+  const {setPhase, transitNextState} = useCreateScenario();
   const onPress = (type: string) => {
     if (type === 'criminal') {
-      setIsCreatingCharacter(true);
+      transitNextState(CreateState.CliminalCharacter);
+
       setPhase(prev => prev + 1);
-    } else if (type === 'other') {
-      setIsCreatingCharacter(true);
-      setIsOther(true);
+      return;
+    }
+
+    if (type === 'other') {
+      transitNextState(CreateState.OtherCharacter);
+      setPhase(prev => prev + 1);
+
+      return;
     }
   };
   return <SelectCharacterTypePresenter onPress={onPress} />;

--- a/frontend/src/pages/CreateScenario/SelectClueType/index.tsx
+++ b/frontend/src/pages/CreateScenario/SelectClueType/index.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import SelectClueTypePresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 
 const SelectClueType = () => {
-  const {setPhase, setTabId, setIsItemInfo} = useCreateScenario();
+  const {setPhase, setTabId, transitNextState} = useCreateScenario();
   const onPress = (type: string) => {
     if (type === 'room') {
-    } else if (type === 'item') {
+      transitNextState(CreateState.Room);
+      return;
+    }
+
+    if (type === 'item') {
       setTabId(prev => prev + 1);
       setPhase(prev => prev + 1);
-      setIsItemInfo(true);
+      transitNextState(CreateState.ItemInfo);
+      return;
     }
   };
   return <SelectClueTypePresenter onPress={onPress} />;

--- a/frontend/src/pages/CreateScenario/Trick/index.tsx
+++ b/frontend/src/pages/CreateScenario/Trick/index.tsx
@@ -1,11 +1,9 @@
 import React, {useState} from 'react';
 import TrickPresenter from './presenter';
-import {Text, View} from 'react-native';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 
 const Trick = () => {
-  const {setPhase, setTabId, setIsTrick, setIsCreatingCharacter} =
-    useCreateScenario();
+  const {setPhase, setTabId, transitNextState} = useCreateScenario();
   const [selectedTricks, setSelectedTricks] = useState<string[]>([]);
   const onPress = () => {
     // fetchする
@@ -13,8 +11,8 @@ const Trick = () => {
 
     setPhase(2);
     setTabId(1);
-    setIsTrick(false);
-    setIsCreatingCharacter(true);
+
+    transitNextState(CreateState.OtherCharacter);
   };
   return (
     <TrickPresenter

--- a/frontend/src/pages/CreateScenario/World/index.tsx
+++ b/frontend/src/pages/CreateScenario/World/index.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import WorldPresenter from './presenter';
-import {useCreateScenario} from '../createScenario';
+import {CreateState, useCreateScenario} from '../createScenario';
 import {extractJson} from '../utility';
 
 type Data = {item: string[]; trivia: string[]};
@@ -19,14 +19,8 @@ const World = () => {
     '高度が高くなると酸素濃度が低くなる',
   ];
 
-  const {
-    setIsWorld,
-    setPhase,
-    setIsHint,
-    setItems,
-    setPhenomena,
-    setShareJson,
-  } = useCreateScenario();
+  const {setPhase, setItems, setPhenomena, setShareJson, transitNextState} =
+    useCreateScenario();
   const [worldItemText, setWorldItemText] = useState('');
   const onPress = (name: string) => {
     setWorldItemText(name);
@@ -55,8 +49,7 @@ const World = () => {
     // ここでfetchして、itemsとphenomenaを更新する(今はダミー)
     setItems(castedData.item);
     setPhenomena(castedData.trivia);
-    setIsWorld(false);
-    setIsHint(true);
+    transitNextState(CreateState.Trick);
     setPhase(prev => prev + 1);
   };
   return <WorldPresenter onPress={onPress} next={next} value={worldItemText} />;

--- a/frontend/src/pages/CreateScenario/createScenario.tsx
+++ b/frontend/src/pages/CreateScenario/createScenario.tsx
@@ -14,6 +14,18 @@ type Character = {
   purpose: string;
 };
 
+export enum CreateState {
+  Default,
+  CliminalCharacter,
+  OtherCharacter,
+  ItemInfo,
+  World,
+  Hint,
+  Trick,
+  Image,
+  Room,
+}
+
 type CreateScenarioContextType = {
   tabId: number;
   setTabId: React.Dispatch<React.SetStateAction<number>>;
@@ -63,6 +75,12 @@ type CreateScenarioContextType = {
   setIsImageCreate: React.Dispatch<React.SetStateAction<boolean>>;
   shareJson: any;
   setShareJson: React.Dispatch<React.SetStateAction<any>>;
+  createState: CreateState;
+  setCreateState: React.Dispatch<React.SetStateAction<CreateState>>;
+  pageStack: CreateState[];
+  setPageStack: React.Dispatch<React.SetStateAction<CreateState[]>>;
+  transitNextState: (createState: CreateState) => void;
+  transitPrevState: () => void;
 };
 
 const CreateScenarioContext = createContext<
@@ -120,6 +138,22 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
   const [isItemInfo, setIsItemInfo] = useState<boolean>(false);
   const [isImageCreate, setIsImageCreate] = useState<boolean>(false);
   const [shareJson, setShareJson] = useState({});
+  const [createState, setCreateState] = useState(CreateState.Default);
+  const [pageStack, setPageStack] = useState([CreateState.Default]);
+
+  const transitNextState = (createState: CreateState) => {
+    setPageStack([...pageStack, createState]);
+    setCreateState(createState);
+  };
+
+  const transitPrevState = () => {
+    const bufStack: CreateState[] = [...pageStack];
+
+    bufStack.pop();
+    setPageStack([...bufStack]); // NOTE: ディープコピーにすることで後述の副作用を回避
+
+    setCreateState(bufStack.pop() || CreateState.Default);
+  };
 
   return (
     <CreateScenarioContext.Provider
@@ -158,6 +192,12 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
         setIsImageCreate,
         shareJson,
         setShareJson,
+        createState,
+        setCreateState,
+        pageStack,
+        setPageStack,
+        transitNextState,
+        transitPrevState,
       }}>
       {children}
     </CreateScenarioContext.Provider>

--- a/frontend/src/pages/CreateScenario/index.tsx
+++ b/frontend/src/pages/CreateScenario/index.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
 import CreateScenarioPresenter from './presenter';
-import {TabView, SceneMap, TabBar} from 'react-native-tab-view';
+import {SceneMap} from 'react-native-tab-view';
 import {View, useWindowDimensions} from 'react-native';
 import {CreateScenarioProvider, useCreateScenario} from './createScenario';
 import {NativeStackScreenProps} from '@react-navigation/native-stack';

--- a/frontend/src/pages/CreateScenario/presenter.tsx
+++ b/frontend/src/pages/CreateScenario/presenter.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import {View} from 'react-native';
 import Header from './Header';
 import {TabBar, TabView} from 'react-native-tab-view';
 import styles from './style';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootRoutesParamList} from '../../routes/Root';
-import {useCreateScenario} from './createScenario';
+import {CreateState , useCreateScenario} from './createScenario';
 import CharacterSheet from './CharacterSheet';
 import World from './World';
 import Hint from './Hint';
 import Trick from './Trick';
 import ItemInfo from './ItemInfo';
-import ImageCreate from './ImageCreate';
 
 type Props = {
   tabViewProps: {
@@ -33,31 +32,35 @@ type Props = {
 
 const CreateScenarioPresenter = ({tabViewProps, navigation}: Props) => {
   const {
-    isCreatingCharacter,
-    isItemInfo,
-    isWorld,
-    isHint,
-    isTrick,
-    isImageCreate,
+    createState,
   } = useCreateScenario();
 
   const renderContent = () => {
-    if (isCreatingCharacter) return <CharacterSheet />;
-    else if (isWorld) return <World />;
-    else if (isHint) return <Hint />;
-    else if (isTrick) return <Trick />;
-    else if (isItemInfo) return <ItemInfo />;
-    else if (isImageCreate) return <ImageCreate />;
-    else
-      return (
-        <TabView
-          navigationState={{index, routes}}
-          renderScene={renderScene}
-          onIndexChange={setIndex}
-          initialLayout={{width: initialLayout.width}}
-          renderTabBar={renderTabBar}
-        />
-      );
+    switch (createState) {
+      case CreateState.CliminalCharacter:
+      case CreateState.OtherCharacter:
+        return <CharacterSheet />;
+      case CreateState.World:
+        return <World />;
+      case CreateState.Hint:
+        return <Hint />;
+      case CreateState.ItemInfo:
+        return <ItemInfo />;
+      case CreateState.Image:
+        return <ItemInfo />;
+      case CreateState.Trick:
+          return <Trick />;
+      default:
+        return (
+          <TabView
+            navigationState={{index, routes}}
+            renderScene={renderScene}
+            onIndexChange={setIndex}
+            initialLayout={{width: initialLayout.width}}
+            renderTabBar={renderTabBar}
+          />
+        );
+    }
   };
 
   const {index, routes, renderScene, setIndex, initialLayout} = tabViewProps;


### PR DESCRIPTION
保守性向上のためのリファクタリング

- 状態遷移の変数保持の仕方を変更
    - `isXXX ` => enum
- ページ遷移状態をスタックで管理し、戻るボタン機能を実装
- ヘッダーの文章も遷移状態で振る舞いを変えるように

close #1 