### PR TITLE
feat: キャラクターリストの表示

### DIFF
--- a/frontend/ios/sample.xcodeproj/project.pbxproj
+++ b/frontend/ios/sample.xcodeproj/project.pbxproj
@@ -702,7 +702,8 @@
 					"-ld_classic",
 					"-Wl",
 					"-ld_classic",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
@@ -801,7 +802,8 @@
 					"-ld_classic",
 					"-Wl",
 					"-ld_classic",
-					"-Wl -ld_classic ",
+					"-Wl",
+					"-ld_classic",
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;

--- a/frontend/ios/sample/AppDelegate.h
+++ b/frontend/ios/sample/AppDelegate.h
@@ -1,6 +1,6 @@
 #import <RCTAppDelegate.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : RCTAppDelegate
+@interface AppDelegate : NSObject  : RCTAppDelegate
 
 @end

--- a/frontend/src/pages/CreateScenario/CharacterCard/index.tsx
+++ b/frontend/src/pages/CreateScenario/CharacterCard/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import CharacterCardPresenter from './presenter';
+import {useCreateScenario, CharacterType, CreateState} from '../createScenario';
+
+export type Props = {
+  character: {
+    name: string;
+    age: number;
+    profession: string;
+    open: string;
+    private: string;
+    timeline: {
+      num: number;
+      text: string;
+    }[];
+    purpose: string;
+  };
+  type: CharacterType;
+};
+
+const CharacterCard = ({character, type}: Props) => {
+  const {setEditingCharacter, transitNextState, setNowCharacterType, setPhase} =
+    useCreateScenario();
+  const onPress = () => {
+    setEditingCharacter(character);
+    transitNextState(CreateState.OtherCharacter);
+    setNowCharacterType(CharacterType.Other);
+    setPhase(prev => prev + 1);
+  };
+  return (
+    <CharacterCardPresenter
+      character={character}
+      type={type}
+      onPress={onPress}
+    />
+  );
+};
+
+export default CharacterCard;

--- a/frontend/src/pages/CreateScenario/CharacterCard/presenter.tsx
+++ b/frontend/src/pages/CreateScenario/CharacterCard/presenter.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import {View, Text, Image, Pressable} from 'react-native';
+import {Props as ContainerProps} from './index';
+import styles from './style';
+
+type Props = {
+  onPress: () => void;
+} & ContainerProps;
+
+const CharacterCardPresenter = ({character, type, onPress}: Props) => {
+  const {name, age, profession, open} = character;
+  return (
+    <Pressable onPress={onPress} style={styles.container}>
+      <View style={styles.nameContainer}>
+        {/*<Image source={icon} style={styles.icon} />*/}
+        <Text style={styles.name}>
+          {name}({age})
+        </Text>
+      </View>
+      <View style={styles.descriptionContainer}>
+        <Text style={styles.profession}>職業:{profession}</Text>
+        <Text style={styles.description}>{open}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+export default CharacterCardPresenter;

--- a/frontend/src/pages/CreateScenario/CharacterCard/style.tsx
+++ b/frontend/src/pages/CreateScenario/CharacterCard/style.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet } from "react-native"
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "#2b2b2b",
+    paddingHorizontal: 24
+  },
+  nameContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingTop: 32,
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#484B5B"
+  },
+  icon: {
+    width: 32,
+    height: 32
+  },
+  name: {
+    color: "#fff",
+    fontSize: 13,
+    marginLeft: 16
+  },
+  descriptionContainer: {
+    paddingTop: 16,
+    paddingBottom: 32
+  },
+  profession: { color: "#fff" },
+  description: { color: "#fff" }
+})
+
+export default styles

--- a/frontend/src/pages/CreateScenario/CharacterSheet/style.tsx
+++ b/frontend/src/pages/CreateScenario/CharacterSheet/style.tsx
@@ -15,6 +15,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: '#696969',
     padding: 16,
+    color: '#fff',
   },
   nameInput: {
     height: 48,

--- a/frontend/src/pages/CreateScenario/Header/index.tsx
+++ b/frontend/src/pages/CreateScenario/Header/index.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import HeaderPresenter from './presenter';
-import {CreateState, useCreateScenario} from '../createScenario';
+import {CreateState, CharacterType, useCreateScenario} from '../createScenario';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootRoutesParamList} from '../../../routes/Root';
 
@@ -20,8 +20,15 @@ const Header = ({navigation}: Props) => {
     createState,
     pageStack,
     transitPrevState,
+    tabId,
+    editingCharacter,
+    nowCharacterType,
+    setCriminal,
+    setOtherCharacters,
+    transitNextState,
   } = useCreateScenario();
   const [headerText, setHeaderText] = useState<string>('シナリオ作成');
+
   useEffect(() => {
     switch (createState) {
       case CreateState.CliminalCharacter:
@@ -50,18 +57,34 @@ const Header = ({navigation}: Props) => {
   }, [createState]);
 
   const back = () => {
-    transitPrevState();
-
     if (pageStack.length === 0) {
       navigation.navigate('ServerSelect');
     }
 
     if (phase === 2) {
+      if (tabId === 1 && editingCharacter) {
+        switch (nowCharacterType) {
+          case CharacterType.Criminal:
+            setCriminal(editingCharacter);
+            break;
+          case CharacterType.Other:
+            setOtherCharacters(prev => [...prev, editingCharacter]);
+            break;
+        }
+      }
+      transitNextState(CreateState.Default); // トリック選択からキャラクターシートに遷移したときに、transitPrevState()を呼ぶと、トリック選択に戻ってしまうので、ここでtransitNextState()を呼ぶ
+      setPhase(phase - 1);
+
       setIsCreatingCharacter(false);
+
+      return;
     }
     if (phase > 1) setPhase(phase - 1);
     else navigation.navigate('ServerSelect');
+
+    transitPrevState();
   };
+
   return <HeaderPresenter back={back} text={headerText} />;
 };
 

--- a/frontend/src/pages/CreateScenario/SelectCharacterType/index.tsx
+++ b/frontend/src/pages/CreateScenario/SelectCharacterType/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import SelectCharacterTypePresenter from './presenter';
-import {CreateState, useCreateScenario} from '../createScenario';
+import {CreateState, CharacterType, useCreateScenario} from '../createScenario';
 
 const SelectCharacterType = () => {
-  const {setPhase, transitNextState} = useCreateScenario();
+  const {setPhase, transitNextState, setNowCharacterType} = useCreateScenario();
   const onPress = (type: string) => {
     if (type === 'criminal') {
       transitNextState(CreateState.CliminalCharacter);
+      setNowCharacterType(CharacterType.Criminal);
 
       setPhase(prev => prev + 1);
       return;
@@ -14,6 +15,7 @@ const SelectCharacterType = () => {
 
     if (type === 'other') {
       transitNextState(CreateState.OtherCharacter);
+      setNowCharacterType(CharacterType.Other);
       setPhase(prev => prev + 1);
 
       return;

--- a/frontend/src/pages/CreateScenario/SelectCharacterType/presenter.tsx
+++ b/frontend/src/pages/CreateScenario/SelectCharacterType/presenter.tsx
@@ -2,23 +2,27 @@ import React from 'react';
 import {Text, View} from 'react-native';
 import styles from './style';
 import SquareButton from '../SquareButton';
-import {useCreateScenario} from '../createScenario';
+import {useCreateScenario, CharacterType} from '../createScenario';
+import CharacterCard from '../CharacterCard';
 
 type Props = {
   onPress: (type: string) => void;
 };
 
 const SelectCharacterTypePresenter = ({onPress}: Props) => {
-  const {criminals, otherCharacters} = useCreateScenario();
+  const {criminal, otherCharacters} = useCreateScenario();
   return (
     <View style={styles.container}>
-      {criminals.length == 0 ? (
+      {criminal ? (
+        <View>
+          <Text style={styles.text}>犯人役のキャラクター</Text>
+          <CharacterCard character={criminal} type={CharacterType.Criminal} />
+        </View>
+      ) : (
         <View>
           <Text style={styles.text}>犯人役のキャラクター</Text>
           <SquareButton type="criminal" onPress={() => onPress('criminal')} />
         </View>
-      ) : (
-        <View></View>
       )}
 
       <Text style={styles.text}>その他のキャラクター</Text>

--- a/frontend/src/pages/CreateScenario/SelectClueType/presenter.tsx
+++ b/frontend/src/pages/CreateScenario/SelectClueType/presenter.tsx
@@ -9,10 +9,10 @@ type Props = {
 };
 
 const SelectClueTypePresenter = ({onPress}: Props) => {
-  const {criminals, otherCharacters} = useCreateScenario();
+  const {criminal, otherCharacters} = useCreateScenario();
   return (
     <View style={styles.container}>
-      {criminals.length == 0 ? (
+      {criminal ? (
         <View>
           <Text style={styles.text}>フロアマップ</Text>
           <SquareButton type="room" onPress={() => onPress('room')} />

--- a/frontend/src/pages/CreateScenario/Trick/index.tsx
+++ b/frontend/src/pages/CreateScenario/Trick/index.tsx
@@ -8,12 +8,26 @@ const Trick = () => {
   const [selectedTricks, setSelectedTricks] = useState<string[]>([]);
   const onPress = () => {
     // fetchする
-    console.log(selectedTricks);
 
     setPhase(2);
     setTabId(1);
 
     transitNextState(CreateState.OtherCharacter);
+
+    setEditingCharacter({
+      name: '竹下波瑠',
+      age: 52,
+      profession: 'マジシャン',
+      open: 'aaaaa',
+      private: 'bbbbb',
+      timeline: [
+        {
+          num: 0,
+          text: 'aaaaaa',
+        },
+      ],
+      purpose: 'bbbbbb',
+    });
   };
   return (
     <TrickPresenter

--- a/frontend/src/pages/CreateScenario/createScenario.tsx
+++ b/frontend/src/pages/CreateScenario/createScenario.tsx
@@ -26,13 +26,19 @@ export enum CreateState {
   Room,
 }
 
+export enum CharacterType {
+  Default,
+  Criminal,
+  Other,
+}
+
 type CreateScenarioContextType = {
   tabId: number;
   setTabId: React.Dispatch<React.SetStateAction<number>>;
   phase: number;
   setPhase: React.Dispatch<React.SetStateAction<number>>;
-  criminals: Character[];
-  setCriminals: React.Dispatch<React.SetStateAction<Character[]>>;
+  criminal: Character | undefined;
+  setCriminal: React.Dispatch<React.SetStateAction<Character | undefined>>;
   otherCharacters: Character[];
   setOtherCharacters: React.Dispatch<React.SetStateAction<Character[]>>;
   isCreatingCharacter: boolean;
@@ -81,6 +87,8 @@ type CreateScenarioContextType = {
   setPageStack: React.Dispatch<React.SetStateAction<CreateState[]>>;
   transitNextState: (createState: CreateState) => void;
   transitPrevState: () => void;
+  nowCharacterType: CharacterType;
+  setNowCharacterType: React.Dispatch<React.SetStateAction<CharacterType>>;
 };
 
 const CreateScenarioContext = createContext<
@@ -102,7 +110,7 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
 }) => {
   const [tabId, setTabId] = useState<number>(1);
   const [phase, setPhase] = useState<number>(1);
-  const [criminals, setCriminals] = useState<Character[]>([]);
+  const [criminal, setCriminal] = useState<Character>();
   const [otherCharacters, setOtherCharacters] = useState<Character[]>([]);
   const [isCreatingCharacter, setIsCreatingCharacter] =
     useState<boolean>(false);
@@ -140,6 +148,9 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
   const [shareJson, setShareJson] = useState({});
   const [createState, setCreateState] = useState(CreateState.Default);
   const [pageStack, setPageStack] = useState([CreateState.Default]);
+  const [nowCharacterType, setNowCharacterType] = useState(
+    CharacterType.Default,
+  );
 
   const transitNextState = (createState: CreateState) => {
     setPageStack([...pageStack, createState]);
@@ -162,8 +173,8 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
         setTabId,
         phase,
         setPhase,
-        criminals,
-        setCriminals,
+        criminal,
+        setCriminal,
         otherCharacters,
         setOtherCharacters,
         isCreatingCharacter,
@@ -198,6 +209,8 @@ export const CreateScenarioProvider: React.FC<{children: ReactNode}> = ({
         setPageStack,
         transitNextState,
         transitPrevState,
+        nowCharacterType,
+        setNowCharacterType,
       }}>
       {children}
     </CreateScenarioContext.Provider>

--- a/frontend/src/pages/CreateScenario/presenter.tsx
+++ b/frontend/src/pages/CreateScenario/presenter.tsx
@@ -5,7 +5,7 @@ import {TabBar, TabView} from 'react-native-tab-view';
 import styles from './style';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RootRoutesParamList} from '../../routes/Root';
-import {CreateState , useCreateScenario} from './createScenario';
+import {CreateState, useCreateScenario} from './createScenario';
 import CharacterSheet from './CharacterSheet';
 import World from './World';
 import Hint from './Hint';
@@ -31,9 +31,9 @@ type Props = {
 };
 
 const CreateScenarioPresenter = ({tabViewProps, navigation}: Props) => {
-  const {
-    createState,
-  } = useCreateScenario();
+  const {createState, criminal} = useCreateScenario();
+
+  console.log(criminal);
 
   const renderContent = () => {
     switch (createState) {
@@ -49,7 +49,7 @@ const CreateScenarioPresenter = ({tabViewProps, navigation}: Props) => {
       case CreateState.Image:
         return <ItemInfo />;
       case CreateState.Trick:
-          return <Trick />;
+        return <Trick />;
       default:
         return (
           <TabView


### PR DESCRIPTION
キャラクター作成後にシナリオ作成ページでキャラクターの一覧を表示

制作後キャラクターシート画面に遷移した後、バックボタンを押すとシナリオ作成画面に遷移するように修正

close #8 